### PR TITLE
OPS-3348: Updated README and improved chef support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,6 @@ Steps to run the chef Enterprise Agent:
      cookbook_path [ 'path_to_cookbook',
                     ] ```
 5. One way of executing the cookbook is using chef solo by issuing this command ```chef-solo -j path_to_file.json -c path_to_solo.rb ```.
-6. Agents will start running and should appear in the ThousandEyes Enterprise Agent list.
-7. Create custom tests with the agents using the ThousandEyes App.
-
-
 
 
 License and Authors

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Steps to run the chef Enterprise Agent:
      cookbook_path [ 'path_to_cookbook',
                     ] ```
 5. One way of executing the cookbook is using chef solo by issuing this command ```chef-solo -j path_to_file.json -c path_to_solo.rb ```.
-
+6. Agents will start running and will show up in the ThousandEyes Enterprise Agent list.
 
 License and Authors
 -------------------

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ This cookbook installs and configures the ThousandEyes Enterprise Agent.
 
 Platform
 --------
-- Debian 6 (squeeze) 
 - Ubuntu 14.04(trusty) and 16.04 (xenial)
-- CentOS 6.3+
-- Red Hat 6.3+
+- CentOS 6.3
+- Red Hat 6.3
 
 Requirements
 ------------
@@ -77,9 +76,9 @@ Don't forget to set the attributes based on your use case.
  ```
  {
      "teagent": {
-         "account_token": "your_account_token_goes_here",
+         "account_token": "your_account_token_goes_here"
      },
-     "run_list": ["recipe[teagent]" ] 
+     "run_list": ["recipe[teagent]" ]
  }
  ```
 
@@ -88,7 +87,7 @@ Don't forget to set the attributes based on your use case.
  {
      "teagent": {
          "browserbot": true,
-         "account_token": "your_account_token_goes_here",
+         "account_token": "your_account_token_goes_here"
      },
      "run_list": ["recipe[teagent]" ]
  }  
@@ -100,7 +99,7 @@ Don't forget to set the attributes based on your use case.
      "teagent": {
          "browserbot": true,
          "international_langs": true,
-         "account_token": "your_account_token_goes_here",
+         "account_token": "your_account_token_goes_here"
      },
      "run_list": ["recipe[teagent]" ]
  }
@@ -111,7 +110,7 @@ Don't forget to set the attributes based on your use case.
  {
      "teagent": {
          "account_token": "your_account_token_goes_here",
-         "log_path": "/var/log",
+         "log_path": "/var/log"
      },
      "run_list": ["recipe[teagent]" ]
  }
@@ -123,7 +122,7 @@ Don't forget to set the attributes based on your use case.
      "teagent": {
          "account_token": "your_account_token_goes_here",
          "proxy_host": "proxy.example.com",
-         "proxy_port": "8080",
+         "proxy_port": "8080"
      },
      "run_list": ["recipe[teagent]" ]
  }
@@ -134,16 +133,32 @@ Don't forget to set the attributes based on your use case.
  {
      "teagent": {
          "account_token": "your_account_token_goes_here",
-         "ip_version": "ipv6",
+         "ip_version": "ipv6"
      },
      "run_list": ["recipe[teagent]" ]
  }
  ```
 
-Alternatively Include the teagent recipe to install the ThousandEyes Enterprise 
+Alternatively Include the teagent recipe to install the ThousandEyes Enterprise
 Agent. The only recipe you need to include is the default one.
 
 * `include_recipe 'teagent'`
+
+### Example
+Steps to run the chef Enterprise Agent:
+1. Clone the repository.
+2. Rename the folder to **teagent**.
+3. Create a json file with a valid token as explained in the *Usage* section.
+4. **Optional:** Create a configuration file *solo.rb* with the cookbook path, like this:
+    ```
+     cookbook_path [ 'path_to_cookbook',
+                    ] ```
+5. One way of executing the cookbook is using chef solo by issuing this command ```chef-solo -j path_to_file.json -c path_to_solo.rb ```.
+6. Agents will start running and should appear in the ThousandEyes Enterprise Agent list.
+7. Create custom tests with the agents using the ThousandEyes App.
+
+
+
 
 License and Authors
 -------------------

--- a/recipes/dependency.rb
+++ b/recipes/dependency.rb
@@ -6,15 +6,7 @@
 #
 
 case node['platform']
-when 'debian'
-    if node[:platform_version].to_f >= 6 and node[:platform_version].to_f < 7
-        package 'lsb-release' do
-            action :install
-        end
-        include_recipe 'teagent::repository'
-    else
-        Chef::Application.fatal!('Only Debian 6 (squeeze - 6.x) is supported. Please contact support.')
-    end
+
 when 'ubuntu'
     case node[:platform_version]
     when '14.04' , '16.04'
@@ -29,7 +21,7 @@ when 'rhel','redhat','centos'
     if node[:platform_version].to_f >= 6.3
         include_recipe 'teagent::repository'
     else
-        Chef::Application.fatal!("Please upgrade your operating system (#{node['platform']}) to >= 6.3")
+        Chef::Application.fatal!("Please upgrade your operating system (#{node['platform']}) to = 6.3")
     end
 else
     Chef::Application.fatal!("#{node['platform']} isn't supported.")

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -6,15 +6,7 @@
 #
 
 case node['platform_family']
-when 'debian'
-    repo_path = "/etc/apt/sources.list.d/thousandeyes.list"
-    repo_source = "thousandeyes.list.erb"
-    repo_variables = {:lsbdistcodename => node['lsb']['codename']}
-    pub_key = "thousandeyes-apt-key.pub"
-    pub_key_path = "/etc/apt/trusted.gpg.d"
-    key_add_import = "add-apt-key"
-    key_add_import_cmd = "apt-key add #{pub_key_path}/#{pub_key}"
-    repo_postinst_cmd = "apt-get update"
+
 when 'rhel','fedora'
     if platform?('rhel','redhat')
         repo_os = 'RHEL'
@@ -72,4 +64,3 @@ execute 'repo-postinst' do
     command "#{repo_postinst_cmd}"
     action :nothing
 end
-

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -21,12 +21,7 @@ service 'te-agent' do
             provider Chef::Provider::Service::Upstart
             supports [:restart, :status]
         end
-
-
-    when 'debian'
-        pattern 'te-agent'
-        supports [:restart]
-    end
+        
     #supports [:restart, :status]
     action [:start, :enable]
 end

--- a/templates/default/thousandeyes.list.erb
+++ b/templates/default/thousandeyes.list.erb
@@ -1,2 +1,0 @@
-deb http://apt.thousandeyes.com/ <%= @lsbdistcodename %> main
-


### PR DESCRIPTION
Fixed error en Usage JSON syntax. 
Removed Debian support.
Removed CentOS/RedHat > 6.3 Support (For now).
Updated README with an Example to run the repo.
Deleted file thousandeyes.list.erb used by Debian.
