### PR TITLE
OPS-3348: Fix typo

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -21,7 +21,8 @@ service 'te-agent' do
             provider Chef::Provider::Service::Upstart
             supports [:restart, :status]
         end
-        
+    end
+       
     #supports [:restart, :status]
     action [:start, :enable]
 end


### PR DESCRIPTION
Fixes a typo in service.rb