### PR TITLE
pin an agent version with a canary option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ cookbook-teagent CHANGELOG
 
 This file is used to list changes made in each version of the cookbook-teagent cookbook.
 
+0.3.1
+-----
+- Set the default version to 1.66.1-1~xenial
+- Add an `is_canary` attribute that can override version to be empty
+
 0.3.0
 -----
 - Possibility to use an erb template to generate te-agent.cfg file

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,9 @@
 # Copyright © 2013 ThousandEyes, Inc.
 #
 
+default['teagent']['version'] = '1.66.1-1~xenial'
+default['teagent']['is_canary'] = false
+
 default['teagent']['browserbot'] = false
 default['teagent']['international_langs'] = false
 default['teagent']['ip_version'] = 'ipv4'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'opensource+chef@thousandeyes.com'
 license          'GPLv3'
 description      'Installs and configures the ThousandEyes Enterprise Agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.0'
+version          '0.3.1'
 provides         'teagent'
 chef_version     '>= 12' if respond_to?(:chef_version)
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,7 +7,9 @@
 
 include_recipe 'teagent::dependency' if node['teagent']['set_repo']
 
-package 'te-agent'
+package 'te-agent' do
+    version node['teagent']['version'] unless node['teagent']['is_canary'] 
+end
 
 package 'te-agent-utils' if node['teagent']['agent_utils']
 


### PR DESCRIPTION
Pin an ordained version of the `te-agent` package.

Add an `is_canary` attribute that if set to true will allow the package version to be empty (and therefore pull the latest from the public repository).